### PR TITLE
feat: create default drupal settings.php file for containers

### DIFF
--- a/templates/drupal-php/default.settings.php
+++ b/templates/drupal-php/default.settings.php
@@ -1,0 +1,37 @@
+<?php
+
+// Declare the current env type based on the env vars.
+$ENV_TYPE = $_SERVER['ENVIRONMENT_TYPE'] ?? 'local';
+
+/*
+ * When we use containers based on the wodby/drupal-php base image some configuration is auto-generated based on environment variables.
+ * This file is generated in $CONF_DIR/wodby.settings.php, so we check if this file exists and in this case we include it to set the defaults.
+ */
+if (isset($_SERVER['CONF_DIR'])) {
+  $settings_file =  "{$_SERVER['CONF_DIR']}/wodby.settings.php";
+  file_exists($settings_file) && include $settings_file;
+}
+/*
+ * Next we need to include the settings which are shared for all environments.
+ */
+$settings_file = __DIR__ . '/settings-shared.php';
+file_exists($settings_file) && include $settings_file;
+
+/*
+ * As last two possible overrides we include settings file based on:
+ * - environment type
+ * - environment name, when defined.
+ *
+ * This system allows to extensive overrides while allowing to maintain setting files tracked in the repository.
+ */
+$settings_file = __DIR__ . "/settings.{$ENV_TYPE}.php";
+file_exists($settings_file) && include $settings_file;
+if ($_SERVER['ENVIRONMENT_NAME']) {
+  $settings_file = __DIR__ . "/settings.{$_SERVER['ENVIRONMENT_NAME']}.php";
+  file_exists($settings_file) && include $settings_file;
+}
+
+/*
+ *  Finally we ensure the correct services definitions are loaded depending on the environment.
+ */
+$settings['container_yamls'][] = "{$app_root}/{$site_path}/services.{$ENV_TYPE}.yml";

--- a/templates/drupal-php/default.settings.php
+++ b/templates/drupal-php/default.settings.php
@@ -4,21 +4,18 @@
 $ENV_TYPE = $_SERVER['ENVIRONMENT_TYPE'] ?? 'local';
 
 /*
- * When we use containers based on the wodby/drupal-php base image some configuration is auto-generated based on environment variables.
- * This file is generated in $CONF_DIR/wodby.settings.php, so we check if this file exists and in this case we include it to set the defaults.
+ *  Load the services definitions depending on the environment.
  */
-if (isset($_SERVER['CONF_DIR'])) {
-  $settings_file =  "{$_SERVER['CONF_DIR']}/wodby.settings.php";
-  file_exists($settings_file) && include $settings_file;
-}
+$settings['container_yamls'][] = "{$app_root}/{$site_path}/services.{$ENV_TYPE}.yml";
+
 /*
- * Next we need to include the settings which are shared for all environments.
+ * Include the settings which are shared for all environments.
  */
 $settings_file = __DIR__ . '/settings-shared.php';
 file_exists($settings_file) && include $settings_file;
 
 /*
- * As last two possible overrides we include settings file based on:
+ * Next we include two possible overrides based on:
  * - environment type
  * - environment name, when defined.
  *
@@ -32,6 +29,10 @@ if ($_SERVER['ENVIRONMENT_NAME']) {
 }
 
 /*
- *  Finally we ensure the correct services definitions are loaded depending on the environment.
+ * Lastly when we use containers based on the wodby/drupal-php base image some configuration is auto-generated based on environment variables.
+ * This file is generated in $CONF_DIR/wodby.settings.php, so we check if this file exists and in this case we include it to set the defaults.
  */
-$settings['container_yamls'][] = "{$app_root}/{$site_path}/services.{$ENV_TYPE}.yml";
+if (isset($_SERVER['CONF_DIR'])) {
+  $settings_file =  "{$_SERVER['CONF_DIR']}/wodby.settings.php";
+  file_exists($settings_file) && include $settings_file;
+}


### PR DESCRIPTION
## What

Defines a `settings.php` predefined file to use in all sites which allows for a great deal of overriding without the need to changes.

## Why

Provide a sane default to use in each site we migrate to the new hosting setup. 

## Additional info

- This is backward compatible with the "legacy" hosting environment as it will load the `settings.local.php` file by default.
- This assumes that we use the `wodby/drupal-php` base image, it would be however compatible with pretty much anything else when using the `ENVIRONMENT_TYPE` and `ENVIRONMENT_NAME` environment variables.