### PR TITLE
feat: add sshd and crond containers

### DIFF
--- a/templates/drupal-cron/default.Dockerfile
+++ b/templates/drupal-cron/default.Dockerfile
@@ -4,3 +4,6 @@ FROM wodby/drupal-php:${BASE_TAG}
 ARG COPY_FROM=.
 ARG COPY_TO=.
 COPY --chown=1000:1000 ${COPY_FROM} ${COPY_TO}
+
+# Copy the required crontab file
+COPY ${COPY_FROM}/infrastructure/docker/cron/www-data.crontab /etc/crontabs/www-data

--- a/templates/drupal-cron/default.dockerignore
+++ b/templates/drupal-cron/default.dockerignore
@@ -1,0 +1,13 @@
+.git/
+.ddev/
+.docker/
+
+.github/
+.idea/
+.travis/
+
+/docker-compose*.yml
+
+/deploy/*
+/infrastructure/terraform/
+/logs/*

--- a/templates/drupal-sshd/default.Dockerfile
+++ b/templates/drupal-sshd/default.Dockerfile
@@ -5,6 +5,8 @@ ARG COPY_FROM=.
 ARG COPY_TO=.
 COPY --chown=1000:1000 ${COPY_FROM} ${COPY_TO}
 
+USER root
+
 # Copy Tailscale binaries from the tailscale image on Docker Hub.
 COPY --from=docker.io/tailscale/tailscale:stable /usr/local/bin/tailscaled /var/runtime/tailscaled
 COPY --from=docker.io/tailscale/tailscale:stable /usr/local/bin/tailscale /var/runtime/tailscale
@@ -15,3 +17,5 @@ RUN mkdir -p /var/run && ln -s /tmp/tailscale /var/run/tailscale && \
 
 
 COPY ${COPY_FROM}/infrastructure/docker/sshd/init-tailscale /docker-entrypoint-init.d/
+
+USER wodby

--- a/templates/drupal-sshd/default.Dockerfile
+++ b/templates/drupal-sshd/default.Dockerfile
@@ -1,0 +1,17 @@
+ARG BASE_TAG=8-dev
+FROM wodby/drupal-php:${BASE_TAG}
+
+ARG COPY_FROM=.
+ARG COPY_TO=.
+COPY --chown=1000:1000 ${COPY_FROM} ${COPY_TO}
+
+# Copy Tailscale binaries from the tailscale image on Docker Hub.
+COPY --from=docker.io/tailscale/tailscale:stable /usr/local/bin/tailscaled /var/runtime/tailscaled
+COPY --from=docker.io/tailscale/tailscale:stable /usr/local/bin/tailscale /var/runtime/tailscale
+RUN mkdir -p /var/run && ln -s /tmp/tailscale /var/run/tailscale && \
+    mkdir -p /var/cache && ln -s /tmp/tailscale /var/cache/tailscale && \
+    mkdir -p /var/lib && ln -s /tmp/tailscale /var/lib/tailscale && \
+    mkdir -p /var/task && ln -s /tmp/tailscale /var/task/tailscale
+
+
+COPY ${COPY_FROM}/infrastructure/docker/sshd/init-tailscale /docker-entrypoint-init.d/

--- a/templates/drupal-sshd/init-tailscale
+++ b/templates/drupal-sshd/init-tailscale
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+mkdir -p /tmp/tailscale
+/var/runtime/tailscaled --tun=userspace-networking --socks5-server=localhost:1055 &
+/var/runtime/tailscale up --ssh --authkey=${TAILSCALE_AUTHKEY} --hostname=${TAILSCALE_NAME}
+echo "Tailscale started!"

--- a/templates/nginx/default.Dockerfile
+++ b/templates/nginx/default.Dockerfile
@@ -1,9 +1,8 @@
-ARG BASE_IMAGE
-FROM ${BASE_IMAGE}
+ARG BASE_TAG=8-dev
+FROM wodby/drupal-php:${BASE_TAG}
 
-ARG COPY_FROM
-ARG COPY_TO
-
+ARG COPY_FROM=.
+ARG COPY_TO=.
 COPY --chown=1000:1000 ${COPY_FROM} ${COPY_TO}
 
 # Copy error template

--- a/templates/nginx/default.Dockerfile
+++ b/templates/nginx/default.Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_TAG=8-dev
-FROM wodby/drupal-php:${BASE_TAG}
+FROM wodby/nginx:${BASE_TAG}
 
 ARG COPY_FROM=.
 ARG COPY_TO=.


### PR DESCRIPTION
## What

- Adds the dockerfiles for sshd and crond containers.
- switch from `BASE_IMAGE` to `BASE_TAG`

## Why

- New specialized container builds
- Ensure containers use the correct base image 