### PR TITLE
fix: add Drupal logs directory

### DIFF
--- a/templates/drupal-cron/default.Dockerfile
+++ b/templates/drupal-cron/default.Dockerfile
@@ -11,6 +11,6 @@ COPY ${COPY_FROM}/infrastructure/docker/drupal-cron/www-data.crontab /etc/cronta
 USER root
 
 # Ensure the drupal logs directory exists and is owned by the webserver user.
-RUN mkdir -p /var/www/logs/ && chown www-data:www-data /var/www/logs/
+RUN mkdir -p /var/www/html/logs && chown www-data:www-data /var/www/html/logs
 
 USER wodby

--- a/templates/drupal-cron/default.Dockerfile
+++ b/templates/drupal-cron/default.Dockerfile
@@ -7,3 +7,10 @@ COPY --chown=1000:1000 ${COPY_FROM} ${COPY_TO}
 
 # Copy the required crontab file
 COPY ${COPY_FROM}/infrastructure/docker/drupal-cron/www-data.crontab /etc/crontabs/www-data
+
+USER root
+
+# Ensure the drupal logs directory exists and is owned by the webserver user.
+RUN mkdir -p /var/www/logs/ && chown www-data:www-data /var/www/logs/
+
+USER wodby

--- a/templates/drupal-cron/default.Dockerfile
+++ b/templates/drupal-cron/default.Dockerfile
@@ -11,6 +11,10 @@ COPY ${COPY_FROM}/infrastructure/docker/drupal-cron/www-data.crontab /etc/cronta
 USER root
 
 # Ensure the drupal logs directory exists and is owned by the webserver user.
-RUN mkdir -p /var/www/html/logs && chown www-data:www-data /var/www/html/logs
+ARG DRUPAL_LOGS_DIR=/var/www/html/logs
+RUN set -e ;\
+  mkdir -p ${DRUPAL_LOGS_DIR} ;\
+  chown www-data:www-data ${DRUPAL_LOGS_DIR} ;\
+  chmod 775 ${DRUPAL_LOGS_DIR}
 
 USER wodby

--- a/templates/drupal-php/default.Dockerfile
+++ b/templates/drupal-php/default.Dockerfile
@@ -8,6 +8,10 @@ COPY --chown=1000:1000 ${COPY_FROM} ${COPY_TO}
 USER root
 
 # Ensure the drupal logs directory exists and is owned by the webserver user.
-RUN mkdir -p /var/www/html/logs && chown www-data:www-data /var/www/html/logs
+ARG DRUPAL_LOGS_DIR=/var/www/html/logs
+RUN set -e ;\
+  mkdir -p ${DRUPAL_LOGS_DIR} ;\
+  chown www-data:www-data ${DRUPAL_LOGS_DIR} ;\
+  chmod 775 ${DRUPAL_LOGS_DIR}
 
 USER wodby

--- a/templates/drupal-php/default.Dockerfile
+++ b/templates/drupal-php/default.Dockerfile
@@ -8,6 +8,6 @@ COPY --chown=1000:1000 ${COPY_FROM} ${COPY_TO}
 USER root
 
 # Ensure the drupal logs directory exists and is owned by the webserver user.
-RUN mkdir -p /var/www/logs/ && chown www-data:www-data /var/www/logs/
+RUN mkdir -p /var/www/html/logs && chown www-data:www-data /var/www/html/logs
 
 USER wodby

--- a/templates/drupal-php/default.Dockerfile
+++ b/templates/drupal-php/default.Dockerfile
@@ -4,3 +4,10 @@ FROM wodby/drupal-php:${BASE_TAG}
 ARG COPY_FROM=.
 ARG COPY_TO=.
 COPY --chown=1000:1000 ${COPY_FROM} ${COPY_TO}
+
+USER root
+
+# Ensure the drupal logs directory exists and is owned by the webserver user.
+RUN mkdir -p /var/www/logs/ && chown www-data:www-data /var/www/logs/
+
+USER wodby

--- a/templates/drupal-tailscale/default.Dockerfile
+++ b/templates/drupal-tailscale/default.Dockerfile
@@ -7,6 +7,9 @@ COPY --chown=1000:1000 ${COPY_FROM} ${COPY_TO}
 
 USER root
 
+# Ensure the drupal logs directory exists and is owned by the webserver user.
+RUN mkdir -p /var/www/logs/ && chown www-data:www-data /var/www/logs/
+
 # Copy Tailscale binaries from the tailscale image on Docker Hub.
 COPY --from=docker.io/tailscale/tailscale:stable /usr/local/bin/tailscaled /usr/local/bin/tailscaled
 COPY --from=docker.io/tailscale/tailscale:stable /usr/local/bin/tailscale /usr/local/bin/tailscale

--- a/templates/drupal-tailscale/default.Dockerfile
+++ b/templates/drupal-tailscale/default.Dockerfile
@@ -8,7 +8,7 @@ COPY --chown=1000:1000 ${COPY_FROM} ${COPY_TO}
 USER root
 
 # Ensure the drupal logs directory exists and is owned by the webserver user.
-RUN mkdir -p /var/www/logs/ && chown www-data:www-data /var/www/logs/
+RUN mkdir -p /var/www/html/logs && chown www-data:www-data /var/www/html/logs
 
 # Copy Tailscale binaries from the tailscale image on Docker Hub.
 COPY --from=docker.io/tailscale/tailscale:stable /usr/local/bin/tailscaled /usr/local/bin/tailscaled

--- a/templates/drupal-tailscale/default.Dockerfile
+++ b/templates/drupal-tailscale/default.Dockerfile
@@ -8,7 +8,11 @@ COPY --chown=1000:1000 ${COPY_FROM} ${COPY_TO}
 USER root
 
 # Ensure the drupal logs directory exists and is owned by the webserver user.
-RUN mkdir -p /var/www/html/logs && chown www-data:www-data /var/www/html/logs
+ARG DRUPAL_LOGS_DIR=/var/www/html/logs
+RUN set -e ;\
+  mkdir -p ${DRUPAL_LOGS_DIR} ;\
+  chown www-data:www-data ${DRUPAL_LOGS_DIR} ;\
+  chmod 775 ${DRUPAL_LOGS_DIR}
 
 # Copy Tailscale binaries from the tailscale image on Docker Hub.
 COPY --from=docker.io/tailscale/tailscale:stable /usr/local/bin/tailscaled /usr/local/bin/tailscaled


### PR DESCRIPTION
## What

Ensure the `/var/www/html/logs` directory exists and it is owned by the `www-data` user.

## Why

Drupal _(via monolog)_ is typically configured to log in this place and if it cannot create the logs file it will fail.

## Additional info

!! UNTESTED