### PR TITLE
✨ Add default environment variables for Drupal setup

### DIFF
--- a/templates/drupal-cron/default.Dockerfile
+++ b/templates/drupal-cron/default.Dockerfile
@@ -9,6 +9,17 @@ COPY --chown=1000:1000 ${COPY_FROM} ${COPY_TO}
 # Copy the required crontab file
 COPY ${COPY_FROM}/infrastructure/docker/drupal-cron/www-data.crontab /etc/crontabs/www-data
 
+# Define our default values for environment variables, those can be overridden at runtime.
+ENV FILES_DIR=/mnt/files
+ENV APP_ROOT=/var/www/html
+ENV DOCROOT_SUBDIR=drupal
+
+ENV DRUPAL_SITE=default
+ENV DRUPAL_ROOT=${APP_ROOT}/${DRUPAL_ROOT}
+ENV DRUPAL_SITE_DIR=$(DRUPAL_ROOT)/sites/$(DRUPAL_SITE)
+ENV DRUPAL_FILES_DIR=${DRUPAL_SITE_DIR}/files
+ENV DRUPAL_FILES_SYNC_SALT=not-in-use-but-required
+
 USER root
 
 # Ensure the drupal logs directory exists and is owned by the webserver user.

--- a/templates/drupal-php/default.Dockerfile
+++ b/templates/drupal-php/default.Dockerfile
@@ -6,6 +6,17 @@ ARG COPY_FROM=.
 ARG COPY_TO=.
 COPY --chown=1000:1000 ${COPY_FROM} ${COPY_TO}
 
+# Define our default values for environment variables, those can be overridden at runtime.
+ENV FILES_DIR=/mnt/files
+ENV APP_ROOT=/var/www/html
+ENV DOCROOT_SUBDIR=drupal
+
+ENV DRUPAL_SITE=default
+ENV DRUPAL_ROOT=${APP_ROOT}/${DRUPAL_ROOT}
+ENV DRUPAL_SITE_DIR=$(DRUPAL_ROOT)/sites/$(DRUPAL_SITE)
+ENV DRUPAL_FILES_DIR=${DRUPAL_SITE_DIR}/files
+ENV DRUPAL_FILES_SYNC_SALT=not-in-use-but-required
+
 USER root
 
 # Ensure the drupal logs directory exists and is owned by the webserver user.

--- a/templates/drupal-tailscale/default.Dockerfile
+++ b/templates/drupal-tailscale/default.Dockerfile
@@ -6,6 +6,17 @@ ARG COPY_FROM=.
 ARG COPY_TO=.
 COPY --chown=1000:1000 ${COPY_FROM} ${COPY_TO}
 
+# Define our default values for environment variables, those can be overridden at runtime.
+ENV FILES_DIR=/mnt/files
+ENV APP_ROOT=/var/www/html
+ENV DOCROOT_SUBDIR=drupal
+
+ENV DRUPAL_SITE=default
+ENV DRUPAL_ROOT=${APP_ROOT}/${DRUPAL_ROOT}
+ENV DRUPAL_SITE_DIR=$(DRUPAL_ROOT)/sites/$(DRUPAL_SITE)
+ENV DRUPAL_FILES_DIR=${DRUPAL_SITE_DIR}/files
+ENV DRUPAL_FILES_SYNC_SALT=not-in-use-but-required
+
 USER root
 
 # Ensure the drupal logs directory exists and is owned by the webserver user.


### PR DESCRIPTION
## What

Defined default values for environment variables related to Drupal setup
such as FILES_DIR, APP_ROOT, DOCROOT_SUBDIR, DRUPAL_SITE, DRUPAL_ROOT,
DRUPAL_SITE_DIR, DRUPAL_FILES_DIR, and DRUPAL_FILES_SYNC_SALT in 
various Dockerfiles.

## Why

This defines the default values which we always set to the same values in the docker-compose.

## Additional Info

This is a low-risk situation, as those can be overridden in the container at runtime anyway.