### PR TITLE
✨ Add symlink creation for PHP storage directory

### DIFF
--- a/templates/drupal-cron/default.Dockerfile
+++ b/templates/drupal-cron/default.Dockerfile
@@ -19,6 +19,16 @@ ENV DRUPAL_ROOT=${APP_ROOT}/${DRUPAL_ROOT}
 ENV DRUPAL_SITE_DIR=$(DRUPAL_ROOT)/sites/$(DRUPAL_SITE)
 ENV DRUPAL_FILES_DIR=${DRUPAL_SITE_DIR}/files
 ENV DRUPAL_FILES_SYNC_SALT=not-in-use-but-required
+ENV DRUPAL_PHP_STORAGE_DIR=/tmp/php
+
+# Creates a symlink to the default location where the persistent files are stored.
+#
+# This is usually done at runtime by calling the makefiles script, but to avoid
+# having to run the script every time the container is started, we do it here for
+# the default location.
+RUN set -e ;\
+  rm -rf "${DRUPAL_SITE_DIR}/files" ;\
+  ln -s "${FILES_DIR}/public" "${DRUPAL_SITE_DIR}/files"
 
 USER root
 
@@ -28,5 +38,9 @@ RUN set -e ;\
   mkdir -p ${DRUPAL_LOGS_DIR} ;\
   chown www-data:www-data ${DRUPAL_LOGS_DIR} ;\
   chmod 775 ${DRUPAL_LOGS_DIR}
+
+# Ensure the PHP storage directory exists and it is owned by the webserver user
+RUN  mkdir ${DRUPAL_PHP_STORAGE_DIR} ;\
+  chown -R www-data:www-data ${DRUPAL_PHP_STORAGE_DIR}
 
 USER wodby

--- a/templates/drupal-cron/default.Dockerfile
+++ b/templates/drupal-cron/default.Dockerfile
@@ -27,8 +27,8 @@ ENV DRUPAL_PHP_STORAGE_DIR=/tmp/php
 # having to run the script every time the container is started, we do it here for
 # the default location.
 RUN set -e ;\
-  rm -rf "${DRUPAL_SITE_DIR}/files" ;\
-  ln -s "${FILES_DIR}/public" "${DRUPAL_SITE_DIR}/files"
+  rm -rvf "${DRUPAL_FILES_DIR}" ;\
+  ln -vs "${FILES_DIR}/public" "${DRUPAL_FILES_DIR}"
 
 USER root
 

--- a/templates/drupal-php/default.Dockerfile
+++ b/templates/drupal-php/default.Dockerfile
@@ -16,6 +16,16 @@ ENV DRUPAL_ROOT=${APP_ROOT}/${DRUPAL_ROOT}
 ENV DRUPAL_SITE_DIR=$(DRUPAL_ROOT)/sites/$(DRUPAL_SITE)
 ENV DRUPAL_FILES_DIR=${DRUPAL_SITE_DIR}/files
 ENV DRUPAL_FILES_SYNC_SALT=not-in-use-but-required
+ENV DRUPAL_PHP_STORAGE_DIR=/tmp/php
+
+# Creates a symlink to the default location where the persistent files are stored.
+#
+# This is usually done at runtime by calling the makefiles script, but to avoid
+# having to run the script every time the container is started, we do it here for
+# the default location.
+RUN set -e ;\
+  rm -rf "${DRUPAL_SITE_DIR}/files" ;\
+  ln -s "${FILES_DIR}/public" "${DRUPAL_SITE_DIR}/files"
 
 USER root
 
@@ -25,5 +35,9 @@ RUN set -e ;\
   mkdir -p ${DRUPAL_LOGS_DIR} ;\
   chown www-data:www-data ${DRUPAL_LOGS_DIR} ;\
   chmod 775 ${DRUPAL_LOGS_DIR}
+
+# Ensure the PHP storage directory exists and it is owned by the webserver user
+RUN  mkdir ${DRUPAL_PHP_STORAGE_DIR} ;\
+  chown -R www-data:www-data ${DRUPAL_PHP_STORAGE_DIR}
 
 USER wodby

--- a/templates/drupal-php/default.Dockerfile
+++ b/templates/drupal-php/default.Dockerfile
@@ -24,8 +24,8 @@ ENV DRUPAL_PHP_STORAGE_DIR=/tmp/php
 # having to run the script every time the container is started, we do it here for
 # the default location.
 RUN set -e ;\
-  rm -rf "${DRUPAL_SITE_DIR}/files" ;\
-  ln -s "${FILES_DIR}/public" "${DRUPAL_SITE_DIR}/files"
+  rm -rvf "${DRUPAL_FILES_DIR}" ;\
+  ln -vs "${FILES_DIR}/public" "${DRUPAL_FILES_DIR}"
 
 USER root
 


### PR DESCRIPTION
## What

1. Ensure the sites/default/files is a symlink to the permanent file storage.
2. Ensure the `/tmp/php` path exists to use for twig compilation.

## Why

Currently we create the symlink using the `make -f /usr/local/bin/actions.mk init-drupal` command when we start the container, which in our scenario [does the same thing](https://github.com/wodby/drupal-php/blob/master/bin/actions.mk#L35) as we are doing here by [calling the `files_link` command](https://github.com/wodby/php/blob/master/8/bin/files_link) (from [the init_drupal](https://github.com/wodby/drupal-php/blob/master/bin/init_drupal#L39)).
  This is not great as it requires an additional step at deploy time, and since we always use the same setup we can hardcode this at build time instead of at run time.


## Additional info

https://github.com/nymedia/akademika_d8/blob/develop/.github/workflows/container-images.yml#L19C1-L20C1

https://github.com/nymedia/github-shared-workflows/blob/1.x/.github/workflows/build-drupal-container-images.yml