### PR TITLE
feat: allow overriding env vars at build time

### DIFF
--- a/templates/drupal-cron/default.Dockerfile
+++ b/templates/drupal-cron/default.Dockerfile
@@ -10,11 +10,16 @@ COPY --chown=1000:1000 ${COPY_FROM} ${COPY_TO}
 COPY ${COPY_FROM}/infrastructure/docker/drupal-cron/www-data.crontab /etc/crontabs/www-data
 
 # Define our default values for environment variables, those can be overridden at runtime.
-ENV FILES_DIR=/mnt/files
-ENV APP_ROOT=/var/www/html
-ENV DOCROOT_SUBDIR=drupal
+ARG FILES_DIR=/mnt/files
+ARG APP_ROOT=/var/www/html
+ARG DOCROOT_SUBDIR=drupal
+ARG DRUPAL_SITE=default
 
-ENV DRUPAL_SITE=default
+ENV FILES_DIR=${FILES_DIR}
+ENV APP_ROOT=${APP_ROOT}
+ENV DOCROOT_SUBDIR=${DOCROOT_SUBDIR}
+
+ENV DRUPAL_SITE=${DRUPAL_SITE}
 ENV DRUPAL_ROOT=${APP_ROOT}/${DOCROOT_SUBDIR}
 ENV DRUPAL_SITE_DIR=${DRUPAL_ROOT}/sites/${DRUPAL_SITE}
 ENV DRUPAL_FILES_DIR=${DRUPAL_SITE_DIR}/files

--- a/templates/drupal-php/default.Dockerfile
+++ b/templates/drupal-php/default.Dockerfile
@@ -7,11 +7,16 @@ ARG COPY_TO=.
 COPY --chown=1000:1000 ${COPY_FROM} ${COPY_TO}
 
 # Define our default values for environment variables, those can be overridden at runtime.
-ENV FILES_DIR=/mnt/files
-ENV APP_ROOT=/var/www/html
-ENV DOCROOT_SUBDIR=drupal
+ARG FILES_DIR=/mnt/files
+ARG APP_ROOT=/var/www/html
+ARG DOCROOT_SUBDIR=drupal
+ARG DRUPAL_SITE=default
 
-ENV DRUPAL_SITE=default
+ENV FILES_DIR=${FILES_DIR}
+ENV APP_ROOT=${APP_ROOT}
+ENV DOCROOT_SUBDIR=${DOCROOT_SUBDIR}
+
+ENV DRUPAL_SITE=${DRUPAL_SITE}
 ENV DRUPAL_ROOT=${APP_ROOT}/${DOCROOT_SUBDIR}
 ENV DRUPAL_SITE_DIR=${DRUPAL_ROOT}/sites/${DRUPAL_SITE}
 ENV DRUPAL_FILES_DIR=${DRUPAL_SITE_DIR}/files

--- a/templates/drupal-tailscale/default.Dockerfile
+++ b/templates/drupal-tailscale/default.Dockerfile
@@ -7,15 +7,21 @@ ARG COPY_TO=.
 COPY --chown=1000:1000 ${COPY_FROM} ${COPY_TO}
 
 # Define our default values for environment variables, those can be overridden at runtime.
-ENV FILES_DIR=/mnt/files
-ENV APP_ROOT=/var/www/html
-ENV DOCROOT_SUBDIR=drupal
+ARG FILES_DIR=/mnt/files
+ARG APP_ROOT=/var/www/html
+ARG DOCROOT_SUBDIR=drupal
+ARG DRUPAL_SITE=default
 
-ENV DRUPAL_SITE=default
+ENV FILES_DIR=${FILES_DIR}
+ENV APP_ROOT=${APP_ROOT}
+ENV DOCROOT_SUBDIR=${DOCROOT_SUBDIR}
+
+ENV DRUPAL_SITE=${DRUPAL_SITE}
 ENV DRUPAL_ROOT=${APP_ROOT}/${DOCROOT_SUBDIR}
 ENV DRUPAL_SITE_DIR=${DRUPAL_ROOT}/sites/${DRUPAL_SITE}
 ENV DRUPAL_FILES_DIR=${DRUPAL_SITE_DIR}/files
 ENV DRUPAL_FILES_SYNC_SALT=not-in-use-but-required
+ENV DRUPAL_PHP_STORAGE_DIR=/tmp/php
 
 USER root
 


### PR DESCRIPTION
## What

- Use `ARG` instead of `ENV` for FILES_DIR, APP_ROOT, DOCROOT_SUBDIR, and
  DRUPAL_SITE in drupal-cron, drupal-tailscale, and drupal-php Dockerfiles.

## Why

I was under the impression that `ENV` would be overridden when using `--build-arg`, however this is **not the case**, so this change allows overriding at build time.