### PR TITLE
feat: configure Drupal file paths in Nginx Dockerfile

### DIFF
--- a/templates/nginx/default.Dockerfile
+++ b/templates/nginx/default.Dockerfile
@@ -6,5 +6,29 @@ ARG COPY_FROM=.
 ARG COPY_TO=.
 COPY --chown=1000:1000 ${COPY_FROM} ${COPY_TO}
 
+# Define our default values for environment variables, those can be overridden at runtime.
+ARG FILES_DIR=/mnt/files
+ARG APP_ROOT=/var/www/html
+ARG DOCROOT_SUBDIR=drupal
+ARG DRUPAL_SITE=default
+
+ENV FILES_DIR=${FILES_DIR}
+ENV APP_ROOT=${APP_ROOT}
+ENV DOCROOT_SUBDIR=${DOCROOT_SUBDIR}
+
+ENV DRUPAL_SITE=${DRUPAL_SITE}
+ENV DRUPAL_ROOT=${APP_ROOT}/${DOCROOT_SUBDIR}
+ENV DRUPAL_SITE_DIR=${DRUPAL_ROOT}/sites/${DRUPAL_SITE}
+ENV DRUPAL_FILES_DIR=${DRUPAL_SITE_DIR}/files
+
+# Creates a symlink to the default location where the persistent files are stored.
+#
+# This is usually done at runtime by calling the makefiles script, but to avoid
+# having to run the script every time the container is started, we do it here for
+# the default location.
+RUN set -e ;\
+  rm -rvf "${DRUPAL_FILES_DIR}" ;\
+  ln -vs "${FILES_DIR}/public" "${DRUPAL_FILES_DIR}"
+
 # Copy error template
 COPY ${COPY_FROM}/infrastructure/docker/nginx/50x.html.tmpl /etc/gotpl/50x.html.tmpl


### PR DESCRIPTION
## What

This change sets up the default environment variables and file paths for a Drupal application running in an Nginx container. It creates a symlink to the default location where the persistent files are stored, which is usually done at runtime by calling the makefiles script. This change ensures that the file paths are properly configured without having to run the script every time the container is started.

## Why

Currently we create the symlink using the `make -f /usr/local/bin/actions.mk init` command when we start the container, which [calls the `init` script](https://github.com/wodby/nginx/blob/master/bin/actions.mk#L13) and in our scenario [does the same thing](https://github.com/wodby/nginx/blob/master/bin/init#L23) as we are doing here by [calling the `files_link` command](https://github.com/wodby/nginx/blob/master/bin/files_link).

This is not great as it requires an additional step at deploy time, and since we always use the same setup we can hardcode this at build time instead of at run time.

## Additional info

This is the nginx companion of previous PRs: https://github.com/nymedia/container-build-defaults/pull/7