### PR TITLE
feat(drupal-tailscale): Add script to save environment variables

### DIFF
--- a/templates/drupal-tailscale/default.Dockerfile
+++ b/templates/drupal-tailscale/default.Dockerfile
@@ -37,7 +37,15 @@ COPY --from=docker.io/tailscale/tailscale:stable /usr/local/bin/tailscaled /usr/
 COPY --from=docker.io/tailscale/tailscale:stable /usr/local/bin/tailscale /usr/local/bin/tailscale
 COPY --from=docker.io/tailscale/tailscale:stable /usr/local/bin/containerboot /usr/local/bin/ts-containerboot
 
-COPY ${COPY_FROM}/infrastructure/docker/drupal-tailscale/init-tailscale.sh /docker-entrypoint-init.d/
+ARG TAILSCALE_STARTUP_SCRIPT="${COPY_FROM}/infrastructure/docker/drupal-tailscale/init-tailscale.sh"
+ADD --chmod=755 "${TAILSCALE_STARTUP_SCRIPT}" /docker-entrypoint-init.d/
+
+#
+# Temporary entrypoint script to handle env variables.
+#
+# Required until this is solved https://github.com/tailscale/tailscale/issues/12395
+ARG SAVE_ENV_SCRIPT_URL=https://raw.githubusercontent.com/nymedia/container-build-defaults/1.x/templates/drupal-tailscale/save-env.sh
+ADD --chmod=755 "${SAVE_ENV_SCRIPT_URL}" /docker-entrypoint-init.d/
 
 # Set default values for Tailscale environment variables.
 ENV TS_USERSPACE=true

--- a/templates/drupal-tailscale/save-env.sh
+++ b/templates/drupal-tailscale/save-env.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# This script saves a predefined list of environment variables to a file.
+#
+# We chose the file "/etc/profile" because it is sourced by the shell on login.
+#
+##########
+# Why do we need to save the environment variables, you might ask?
+##########
+# Because of a bug/limitation in the way Tailscale SSH runs commands:
+# https://github.com/tailscale/tailscale/issues/12395
+#
+# Until the bug is fixed, we need to save the environment variables to a file
+# so that they are available when the shell is started by Tailscale SSH.
+#
+##########
+
+if [ "${DEBUG:-no}" != "no" ]; then
+  set -x
+fi
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This file will be sourced by the shell on login
+DEST_FILE="${HOME}/.shrc"
+
+# Define a list of environment variables that should be excluded.
+# These are the environment variables that are set by the shell itself and
+# should not be saved to the file to avoid conflicts.
+declare -a exclude_vars=(
+  "CHARSET"
+  "COLUMNS"
+  "ENV"
+  "GPG_KEYS"
+  "HOME"
+  "HOSTNAME"
+  "LANG"
+  "LC_ADDRESS"
+  "LC_COLLATE"
+  "LC_IDENTIFICATION"
+  "LC_MEASUREMENT"
+  "LC_MONETARY"
+  "LC_NAME"
+  "LC_NUMERIC"
+  "LC_PAPER"
+  "LC_TELEPHONE"
+  "LC_TIME"
+  "PAGER"
+  "PATH"
+  "PS1"
+  "PWD"
+  "ROWS"
+  "SHELL"
+  "SHLVL"
+  "SSH_CLIENT"
+  "SSH_CONNECTION"
+  "SSH_TTY"
+  "TERM"
+  "TS_AUTH_ONCE"
+  "TS_AUTHKEY"
+  "TS_EXTRA_ARGS"
+  "TS_HOSTNAME"
+  "TS_SOCKET"
+  "TS_STATE_DIR"
+  "TS_USERSPACE"
+  "USER"
+)
+
+for var_name in $(printenv | cut -d= -f1); do
+  if [[ ! " ${exclude_vars[@]} " =~ " ${var_name} " ]]; then
+    var_names+=("${var_name}")
+  fi
+done
+
+# Save the environment variables to the file
+echo "The following environment variables will be saved to ${DEST_FILE}:"
+echo "${var_names[@]}"
+
+for var_name in "${var_names[@]}"; do
+  echo "export ${var_name}='$(printenv "${var_name}")'" >> "${DEST_FILE}"
+done
+
+# Ensure that the environment variables are loaded by any shell:
+# https://github.com/wodby/php/blob/24c9b29ab5e32328173fd23124d09a2d80baca5b/8/Dockerfile#L334-L335
+cp "${HOME}/.shrc" "${HOME}/.bashrc"
+cp "${HOME}/.shrc" "${HOME}/.bash_profile"


### PR DESCRIPTION
## What

This adds a script which at container startup will saves all the environment variables to the shell RC files (for ash, sh and bash).

ℹ️ The script contains a block-list for env vars which should be defined at runtime by the shell to avoid issues.

## Why

This is a temporary solution to handle a bug/limitation in the way Tailscale SSH starts new shells. The result is that env vars are not available in the shell as described in the issue https://github.com/tailscale/tailscale/issues/12395.

Until the bug is fixed, this script ensures that all the environment variables are available when the shell is started by Tailscale SSH.

## Additional Info

Beside the bug report we have a case open with tailscale support: TSS-40162

✔️ Manually tested with local containers.