### PR TITLE
feat(drupal-cron): default command for cron container

### DIFF
--- a/templates/drupal-cron/default.Dockerfile
+++ b/templates/drupal-cron/default.Dockerfile
@@ -49,3 +49,6 @@ RUN  mkdir ${DRUPAL_PHP_STORAGE_DIR} ;\
   chown -R www-data:www-data ${DRUPAL_PHP_STORAGE_DIR}
 
 USER wodby
+
+# Start the cron daemon
+CMD [ "sudo", "-E", "crond", "-f", "-d", "0" ]


### PR DESCRIPTION

## What

Sets the default command to be crond daemon to the Drupal Cron Docker container to ensure scheduled tasks are executed as expected.

## Why

This change is not strictly necessary, but it removes the need to have a custom command in the container compose file [as we've been doing until now](https://github.com/Frontkom-SysOps/ansible-docker-compose-server/blob/main/ansible/provisioning/templates/compose/drupal/docker-compose.yml.j2#L32).