### PR TITLE
feat(Dockerfile): add automatic Drupal deploy feature

### DIFF
--- a/templates/drupal-php/default.Dockerfile
+++ b/templates/drupal-php/default.Dockerfile
@@ -23,6 +23,9 @@ ENV DRUPAL_FILES_DIR=${DRUPAL_SITE_DIR}/files
 ENV DRUPAL_FILES_SYNC_SALT=not-in-use-but-required
 ENV DRUPAL_PHP_STORAGE_DIR=/tmp/php
 
+# The following can be set (at runtime) to 'auto' to deploy changes automatically
+ENV DRUPAL_DEPLOY_CHANGES=manual
+
 # Creates a symlink to the default location where the persistent files are stored.
 #
 # This is usually done at runtime by calling the makefiles script, but to avoid
@@ -33,6 +36,13 @@ RUN set -e ;\
   ln -vs "${FILES_DIR}/public" "${DRUPAL_FILES_DIR}"
 
 USER root
+
+# Copy any init script specific to the application
+RUN set -e ;\
+  test -d "${APP_ROOT}/infrastructure/docker/drupal-php/init.d/" && \
+  cp -v "${APP_ROOT}/infrastructure/docker/drupal-php/init.d/"* /docker-entrypoint-init.d/ ;\
+  chmod -c +x /docker-entrypoint-init.d/*
+
 
 # Ensure the drupal logs directory exists and is owned by the webserver user.
 ARG DRUPAL_LOGS_DIR=/var/www/html/logs

--- a/templates/drupal-php/init/50-deploy-changes.sh
+++ b/templates/drupal-php/init/50-deploy-changes.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+if [[ -n "${DEBUG}" ]]; then
+    set -o xtrace
+fi
+
+# Exit cleanly if the "DRUPAL_DEPLOY_CHANGES" env var is not set to "auto".
+if [[ "${DRUPAL_DEPLOY_CHANGES:}" != "auto" ]]; then
+  echo "Skipping automatic drupal deploy."
+  exit 0
+else
+  echo "Starting automatic drupal deploy."
+fi
+
+drsh() {
+  drush --root="${DRUPAL_ROOT}" --uri="${PROJECT_BASE_URL:-}" ${@}
+}
+
+run_query() {
+  $(drsh sql:connect) -s -N -e "${1}"
+}
+
+get_db_version() {
+  local drupal_db_version_key_name="db-schema-version"
+
+  echo $(run_query "SELECT value FROM key_value WHERE collection='frontkom' AND name='${drupal_db_version_key_name}'")
+}
+
+main() {
+  deployment_identifier_file="${APP_ROOT}/.VERSION"
+
+  # Set CWD to App Root.
+  cd "${APP_ROOT}" || (echo "Cannot cd into app root: ${APP_ROOT}" >&2 ; exit)
+
+  # Check if the DB is even populated with a basic table.
+  if [[ "$(run_query "SHOW TABLES LIKE 'key_value';" | wc -l)" -eq 0 ]]; then
+    echo "Quitting: Database not installed."
+    exit 0
+  fi
+
+  # Ensure the deployment identifier file exists.
+  if [[ ! -f "${deployment_identifier_file}" ]]; then
+    echo "Quitting: Missing deployment identifier file: ${deployment_identifier_file}" >&2
+    exit 0
+  fi
+  codebase_version="$(<$deployment_identifier_file)"
+
+  if [[ "$(get_db_version)" == "${codebase_version}" ]]; then
+    echo "Quitting: Database already at latest version." >&2
+    exit 0
+  fi
+
+  # Run deploy actions.
+  ${DRUPAL_DEPLOY_COMMAND:-"composer deploy"}
+
+  # Update the version identifier in the db.
+  upsert_query="INSERT INTO key_value (collection, name, value) \
+    VALUES ('nymedia', '${drupal_db_version_key_name}', '${codebase_version}') \
+    ON DUPLICATE KEY UPDATE value='${codebase_version}';"
+
+  run_query "${upsert_query}"
+}
+
+
+main $@


### PR DESCRIPTION
## What

The changes in this commit add an automatic Drupal deployment feature to the default Dockerfile for the Drupal-PHP template.

The main changes are:

1. Added a new environment variable `DRUPAL_DEPLOY_CHANGES` that can be set to `auto` to enable automatic deployment.
2. Added a new init script `/docker-entrypoint-init.d/50-deploy-changes.sh` that checks the database version and performs a deployment if the codebase version is newer.
3. The init script uses Drush to check the database version, perform the deployment, and update the version identifier in the database.

## Why

This feature allows the Drupal application to be automatically updated when the codebase changes, without the need for manual intervention.

## Additional Context

**Changes required on workflow:** This change requires to also update the "build" workflow to ensure that the init script is included in the container as we already do for things like [the crontab file](https://github.com/nymedia/github-shared-workflows/blob/695d883ba347eb2755275592c20477a92a9fdf13/.github/workflows/build-drupal-container-images.yml#L200-L208), and the [nginx error page](https://github.com/nymedia/github-shared-workflows/blob/695d883ba347eb2755275592c20477a92a9fdf13/.github/workflows/build-drupal-container-images.yml#L220-L228). The only difference from the previous steps is that the job only needs to ensure that the file is pleced in `[repo-root]/infrastructure/docker/drupal-php/init.d` and then the Dockerfile will take care of the rest.

Example:
```
      - name: Setup init
        if: matrix.container-name == 'drupal-php'
        run: |
          deploy_script="infrastructure/docker/drupal-php/init.d/50-deploy-changes.sh"
          if [[ ! -f "${deploy_script}" ]] ; then
            echo "Downloaded default 'deploy' script" >> $GITHUB_STEP_SUMMARY
            mkdir -p $(dirname "${deploy_script}")
            curl -sSL -o "${deploy_script}" "${{ env.BUILD_TEMPLATES_BASE_URL }}/init/50-deploy-changes.sh"
          fi
```


**Used also on:** a slight variation of this is in use [in Sikt with their docker init files](https://github.com/frontkom/sikt-cms/blob/develop/.docker/infra/init/50-deploy-changes.sh).